### PR TITLE
Centralize safe GUI bitmap loading and packaging-safe resource resolution

### DIFF
--- a/scripts/gui/panels/camera_pnl.py
+++ b/scripts/gui/panels/camera_pnl.py
@@ -13,6 +13,7 @@ from panels.rpicap_set_pnl import rpicap_sets_pnl
 from panels.fswebcam_set_pnl import fs_sets_pnl
 from panels.motion_set_pnl import motion_sets_pnl
 from panels.libcam_set_pnl import libcam_sets_pnl
+from shared_data import load_bitmap_safe
 
 
 class ctrl_pnl(scrolled.ScrolledPanel):
@@ -600,7 +601,7 @@ class info_pnl(scrolled.ScrolledPanel):
             img_to_show = img_path
             text_label  = label
         #
-        pic = wx.StaticBitmap(self, -1, wx.Image(img_to_show, wx.BITMAP_TYPE_ANY).ConvertToBitmap())
+        pic = wx.StaticBitmap(self, -1, load_bitmap_safe(img_to_show))
         pic.SetLabel(img_to_show)
         pic.Bind(wx.EVT_LEFT_DOWN, self.pic_click)
 

--- a/scripts/gui/panels/datawall_pnl.py
+++ b/scripts/gui/panels/datawall_pnl.py
@@ -6,6 +6,7 @@ import importlib
 import os
 import sys
 from uitools import MakeDynamicOptPnl
+from shared_data import load_bitmap_safe
 
 class ctrl_pnl(scrolled.ScrolledPanel):
     def __init__(self, parent):
@@ -287,20 +288,7 @@ class info_pnl(scrolled.ScrolledPanel):
             wx.MessageBox(f"Image file not found: {image_path}", "Error", wx.OK | wx.ICON_ERROR)
             return
 
-        try:
-            # Load the image. The BITMAP_TYPE_ANY flag lets wxPython decide the type.
-            img = wx.Image(image_path, wx.BITMAP_TYPE_ANY)
-        except Exception as e:
-            wx.MessageBox(f"Failed to load image: {e}", "Error", wx.OK | wx.ICON_ERROR)
-            return
-
-        # (Optional) If you want to ensure the image is not too large, you can scale it here.
-        # For example:
-        # max_width, max_height = 800, 600
-        # if img.GetWidth() > max_width or img.GetHeight() > max_height:
-        #     img = img.Scale(max_width, max_height, wx.IMAGE_QUALITY_HIGH)
-
-        bmp = wx.Bitmap(img)
+        bmp = load_bitmap_safe(image_path)
         self.image_box.SetBitmap(bmp)
         # Resize the image box to match the bitmap dimensions.
         self.image_box.SetSize(bmp.GetWidth(), bmp.GetHeight())

--- a/scripts/gui/panels/graphs_pnl.py
+++ b/scripts/gui/panels/graphs_pnl.py
@@ -9,6 +9,7 @@ import datetime
 import time
 import sys
 import matplotlib.pyplot as plt
+from shared_data import load_bitmap_safe
 
 class ctrl_pnl(scrolled.ScrolledPanel):
     def __init__(self, parent):
@@ -1841,7 +1842,7 @@ class GraphPanel(wx.Panel):
 
     def add_graph(self, graph_path):
         """Add a graph image to the panel."""
-        bmp = wx.Image(graph_path, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
+        bmp = load_bitmap_safe(graph_path)
         bitmap = wx.StaticBitmap(self, bitmap=bmp)
         bitmap.Bind(wx.EVT_LEFT_DCLICK, lambda event: self.on_double_click(graph_path))
 
@@ -2455,4 +2456,3 @@ class GraphPreset:
             except:
                 pass
         return None
-

--- a/scripts/gui/panels/localfiles_pnl.py
+++ b/scripts/gui/panels/localfiles_pnl.py
@@ -5,6 +5,7 @@ import wx
 import wx.lib.scrolledpanel as scrolled
 import wx.lib.delayedresult as delayedresult
 import wx.lib.newevent
+from shared_data import load_bitmap_safe
 
 FileClearEvent, EVT_FILE_CLEAR = wx.lib.newevent.NewEvent()
 
@@ -1423,9 +1424,10 @@ class info_pnl(scrolled.ScrolledPanel):
     def set_image_preview(self, img_path, place):
         #print("Loading -", img_path, "to", place)
         try:
-            pic = wx.Image(img_path, wx.BITMAP_TYPE_ANY)
-            pic = self.parent.shared_data.scale_pic(pic, 300)
-            pic = pic.ConvertToBitmap()
+            if img_path is None:
+                raise ValueError("No image path provided")
+            pic = load_bitmap_safe(img_path)
+            pic = self.parent.shared_data.scale_pic(pic.ConvertToImage(), 300).ConvertToBitmap()
             if place == 'first':
                 self.photo_folder_first_pic.SetToolTip(img_path)
                 self.photo_folder_first_pic.SetBitmap(pic)

--- a/scripts/gui/panels/sensors_pnl.py
+++ b/scripts/gui/panels/sensors_pnl.py
@@ -3,6 +3,7 @@ import wx
 import sys
 import wx.lib.scrolledpanel as scrolled
 from uitools import RunCmdDialog
+from shared_data import load_bitmap_safe
 import re
 _TIME_RE = re.compile(r"^\s*(\d{1,2}):(\d{2})\s*$")
 _RANGE_RE = re.compile(r"^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$")
@@ -1302,9 +1303,8 @@ class sensor_from_module_dialog(wx.Dialog):
         shared_data = self.parent.parent.parent.shared_data
         guide_path = "guide_" + self.s_type + ".png"
         guide_path = os.path.join(shared_data.sensor_modules_path, guide_path)
-        guide = wx.Image(guide_path, wx.BITMAP_TYPE_ANY)
-        guide = guide.ConvertToBitmap()
         if os.path.isfile(guide_path):
+            guide = load_bitmap_safe(guide_path)
             dbox = shared_data.show_image_dialog(None, guide, self.s_type)
             dbox.ShowModal()
             dbox.Destroy()
@@ -1799,8 +1799,7 @@ class button_dialog(wx.Dialog):
         guide_path = os.path.join(shared_data.ui_img_path, "button_help.png")
 
         if os.path.isfile(guide_path):
-            guide = wx.Image(guide_path, wx.BITMAP_TYPE_ANY)
-            guide = guide.ConvertToBitmap()
+            guide = load_bitmap_safe(guide_path)
             dbox = shared_data.show_image_dialog(None, guide, "Button Help")
             dbox.ShowModal()
             dbox.Destroy()

--- a/scripts/gui/panels/start_pnl.py
+++ b/scripts/gui/panels/start_pnl.py
@@ -2,6 +2,7 @@ import os
 import wx
 import sys
 import importlib
+from shared_data import resolve_resource_path, load_bitmap_safe
 
 
 class ctrl_pnl(wx.Panel):
@@ -233,7 +234,7 @@ class info_pnl(wx.Panel):
     #
     def __init__( self, parent ):
         shared_data = parent.shared_data
-        self.display_image = "./ui_images/splash.png"
+        self.display_image = resolve_resource_path("ui_images", "splash.png")
         wx.Panel.__init__ ( self, parent, id = wx.ID_ANY, pos = (285, 0), size = wx.Size( 910,800 ), style = wx.TAB_TRAVERSAL )
         self.SetBackgroundColour((150,210,170))
         self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)
@@ -246,7 +247,5 @@ class info_pnl(wx.Panel):
                 dc.SetClippingRect(rect)
 
             dc.Clear()
-            img = wx.Image(self.display_image, wx.BITMAP_TYPE_ANY)
-            img = img.Scale(self.GetSize().GetWidth(), self.GetSize().GetHeight(), wx.IMAGE_QUALITY_HIGH)
-            bmp = img.ConvertToBitmap()
+            bmp = load_bitmap_safe(self.display_image, scale_to=(self.GetSize().GetWidth(), self.GetSize().GetHeight()))
             dc.DrawBitmap(bmp, 0, 0)

--- a/scripts/gui/panels/timelapse_pnl.py
+++ b/scripts/gui/panels/timelapse_pnl.py
@@ -6,6 +6,7 @@ import sys
 import datetime
 import wx.lib.delayedresult as delayedresult
 from PIL import Image, ImageDraw, ImageEnhance
+from shared_data import load_bitmap_safe
 
 class ctrl_pnl(wx.Panel):
     #
@@ -807,7 +808,7 @@ class info_pnl(wx.Panel):
             self.graph_image_path = img_path
             # load image and display in box
             try:
-                img = wx.Image(img_path, wx.BITMAP_TYPE_ANY)
+                img = load_bitmap_safe(img_path).ConvertToImage()
                 graph = self.shared_data.scale_pic(img, self.graph_size)
                 graph = graph.ConvertToBitmap()
                 self.graph_image_box.SetBitmap(graph)
@@ -973,7 +974,7 @@ class info_pnl(wx.Panel):
             self.first_img_l.SetLabel(image_title)
 
             try:
-                self.first_ani_pic = wx.Image(image_path, wx.BITMAP_TYPE_ANY)
+                self.first_ani_pic = load_bitmap_safe(image_path).ConvertToImage()
                 first = self.shared_data.scale_pic(self.first_ani_pic, self.pic_size)
                 first = first.ConvertToBitmap()
                 self.first_image.SetBitmap(first)
@@ -1045,7 +1046,7 @@ class info_pnl(wx.Panel):
             self.last_img_l.SetLabel(image_title)
 
             try:
-                self.last_ani_pic = wx.Image(image_path, wx.BITMAP_TYPE_ANY)
+                self.last_ani_pic = load_bitmap_safe(image_path).ConvertToImage()
                 last = self.shared_data.scale_pic(self.last_ani_pic, self.pic_size)
                 last = last.ConvertToBitmap()
                 self.last_image.SetBitmap(last)
@@ -1742,7 +1743,7 @@ class PreviewPanel(wx.Panel):
         wx.Panel.__init__(self, parent)
         self.parent = parent
         self.SetMinSize(wx.Size(790, 400))  # Set a minimum size
-        self.ref_background_image = wx.Image(ref_background_image, wx.BITMAP_TYPE_ANY)
+        self.ref_background_image = load_bitmap_safe(ref_background_image).ConvertToImage()
         self.ref_overlay_image = ref_overlay_image
         self.static_bitmap = wx.StaticBitmap(self, wx.ID_ANY, wx.Bitmap())
 
@@ -1753,7 +1754,7 @@ class PreviewPanel(wx.Panel):
     def update_preview(self, ref_background_image, ref_overlay_image):
         #print(ref_background_image, ref_overlay_image)
         if ref_overlay_image is None:
-            bg_image = wx.Image(ref_background_image, wx.BITMAP_TYPE_ANY)
+            bg_image = load_bitmap_safe(ref_background_image).ConvertToImage()
             self.draw_scaled_image(bg_image)
         else:
             # Draw the overlay on top of the background image

--- a/scripts/gui/shared_data.py
+++ b/scripts/gui/shared_data.py
@@ -5,6 +5,44 @@ import platform
 import datetime
 import wx.lib.scrolledpanel as scrolled
 
+def resolve_resource_path(*parts):
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        base_path = sys._MEIPASS
+    else:
+        base_path = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(base_path, *parts)
+
+def _fallback_bitmap(fallback_art=wx.ART_MISSING_IMAGE, size=None):
+    art_size = wx.Size(32, 32) if size is None else wx.Size(*size)
+    fallback = wx.ArtProvider.GetBitmap(fallback_art, wx.ART_OTHER, art_size)
+    if fallback.IsOk():
+        return fallback
+    return wx.Bitmap(art_size.GetWidth(), art_size.GetHeight())
+
+def load_bitmap_safe(path, fallback_art=wx.ART_MISSING_IMAGE, size=None, scale_to=None):
+    try:
+        if not path:
+            return _fallback_bitmap(fallback_art=fallback_art, size=size or scale_to)
+
+        resolved_path = path if os.path.isabs(path) else resolve_resource_path(path)
+        if not os.path.isfile(resolved_path):
+            print("WARNING: image file missing - " + str(resolved_path))
+            return _fallback_bitmap(fallback_art=fallback_art, size=size or scale_to)
+
+        img = wx.Image(resolved_path, wx.BITMAP_TYPE_ANY)
+        if not img.IsOk():
+            print("WARNING: image failed to load - " + str(resolved_path))
+            return _fallback_bitmap(fallback_art=fallback_art, size=size or scale_to)
+
+        if scale_to:
+            img = img.Scale(scale_to[0], scale_to[1], wx.IMAGE_QUALITY_HIGH)
+        elif size and (img.GetWidth() != size[0] or img.GetHeight() != size[1]):
+            img = img.Scale(size[0], size[1], wx.IMAGE_QUALITY_HIGH)
+        return img.ConvertToBitmap()
+    except Exception as e:
+        print("WARNING: image load error for " + str(path) + " reason: " + str(e))
+        return _fallback_bitmap(fallback_art=fallback_art, size=size or scale_to)
+
 class shared_data:
     def __init__(self, parent):
         self.parent = parent
@@ -50,16 +88,16 @@ class shared_data:
         ## paths
         #
         # gui system paths
-        self.cwd = os.getcwd()
-        self.ui_img_path = os.path.join(self.cwd, "ui_images")
-        self.graph_modules_path = os.path.join(self.cwd, "graph_modules")
-        self.sensor_modules_path = os.path.join(self.cwd, "sensor_modules")
-        self.timelapse_modules_path = os.path.join(self.cwd, "timelapse_modules")
+        self.cwd = resolve_resource_path()
+        self.ui_img_path = resolve_resource_path("ui_images")
+        self.graph_modules_path = resolve_resource_path("graph_modules")
+        self.sensor_modules_path = resolve_resource_path("sensor_modules")
+        self.timelapse_modules_path = resolve_resource_path("timelapse_modules")
         sys.path.append(self.graph_modules_path)
         sys.path.append(self.sensor_modules_path)
         sys.path.append(self.timelapse_modules_path)
-        self.graph_presets_path = os.path.join(self.cwd, "graph_presets")
-        self.datawall_presets_path = os.path.join(self.cwd, "datawall_presets")
+        self.graph_presets_path = resolve_resource_path("graph_presets")
+        self.datawall_presets_path = resolve_resource_path("datawall_presets")
         #
         ## Temporarily Stored data
         #
@@ -81,11 +119,11 @@ class shared_data:
         no_log_img_path = os.path.join(self.ui_img_path, "log_loaded_none.png")
         yes_log_img_path = os.path.join(self.ui_img_path, "log_loaded_true.png")
         warn_log_img_path = os.path.join(self.ui_img_path, "log_loaded_none.png")
-        self.no_log_image = wx.Image(no_log_img_path, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
-        self.yes_log_image = wx.Image(yes_log_img_path, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
-        self.warn_log_image = wx.Image(warn_log_img_path, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
+        self.no_log_image = load_bitmap_safe(no_log_img_path)
+        self.yes_log_image = load_bitmap_safe(yes_log_img_path)
+        self.warn_log_image = load_bitmap_safe(warn_log_img_path)
         infobtn_img_path = os.path.join(self.ui_img_path, "Info_button.png")
-        self.infobtn_image = wx.Image(infobtn_img_path, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
+        self.infobtn_image = load_bitmap_safe(infobtn_img_path)
         #
         ## Fonts
         #
@@ -168,8 +206,7 @@ class shared_data:
         guide_path = os.path.join(self.ui_img_path, img_path)
         if os.path.isfile(guide_path):
             print( " Showing help file - ", guide_path )
-            guide = wx.Image(guide_path, wx.BITMAP_TYPE_ANY)
-            guide = guide.ConvertToBitmap()
+            guide = load_bitmap_safe(guide_path)
             dbox = self.show_image_dialog(None, guide, "Cron Help")
             dbox.ShowModal()
             dbox.Destroy()
@@ -217,7 +254,7 @@ class shared_data:
 
     def get_module_options(self, module_prefix, m_folder="graph_modules"):
         list_of_modules = []
-        modules_folder = os.path.join(os.getcwd(), m_folder)
+        modules_folder = resolve_resource_path(m_folder)
         module_options = os.listdir(modules_folder)
         for file in module_options:
             if module_prefix in file:
@@ -392,8 +429,7 @@ class shared_data:
 
             if type(image_to_show) == type("str"):
                 print("Displaying Image; ", image_to_show)
-                image_to_show = wx.Image(image_to_show, wx.BITMAP_TYPE_ANY)
-                image_to_show = image_to_show.ConvertToBitmap()
+                image_to_show = load_bitmap_safe(image_to_show)
             else:
                 print(type(image_to_show))
 


### PR DESCRIPTION
### Motivation
- The GUI contained many direct `wx.Image(...).ConvertToBitmap()` one-liners which raise C++ `image.IsOK()` assertions and crash the app when images are missing or corrupt, particularly in frozen/packaged builds. 
- Image path resolution relied on `os.getcwd()` which is not packaging-safe (PyInstaller `_MEIPASS`), causing asset lookup failures in bundled executables.

### Description
- Added packaging-safe resource helpers in `scripts/gui/shared_data.py`: `resolve_resource_path(*parts)` and `load_bitmap_safe(path, fallback_art=..., size=None, scale_to=None)` plus a `_fallback_bitmap(...)` helper to produce safe fallback bitmaps. 
- Switched GUI asset roots to use `resolve_resource_path(...)` (replacing `os.getcwd()`-based paths) so assets resolve correctly when frozen. 
- Replaced high-risk image loads with `load_bitmap_safe(...)` across the UI: startup icons/help dialogs and the panels `camera_pnl`, `graphs_pnl`, `start_pnl`, `sensors_pnl`, `localfiles_pnl`, `timelapse_pnl`, and `datawall_pnl` to validate files, scale when requested, and return graceful fallbacks instead of crashing. 
- `load_bitmap_safe` logs warnings on missing/corrupt images, optionally scales images, checks `img.IsOk()` before `ConvertToBitmap()`, and falls back to `wx.ArtProvider` or an empty `wx.Bitmap` on failure to keep UX graceful.

### Testing
- Static scan for direct risky conversions was run with `rg` and no remaining `wx.Image(...).ConvertToBitmap()` one-liners were found in `scripts/gui`. 
- All modified GUI modules were compiled with `python -m compileall`, and compilation completed without syntax errors. 
- A runtime smoke test attempt to exercise `load_bitmap_safe` failed in this environment due to missing `wx` (`ModuleNotFoundError`), so live GUI behavior should be verified in an environment with `wx` (and in a packaged executable) to confirm fallback behavior at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9864f305483259abc594f20f28e11)